### PR TITLE
var name in example corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Stubs can be used to return canned values from method calls, either by extending
 **Stubbing a new method**
 
 ```
-var sum = sinon.stub();
+var func = sinon.stub();
 func.returns(10)
 console.log(func(5,6));   // Gives 10!
 ```


### PR DESCRIPTION
This might confuse a new coder… variable should be named 'func' to match the calls to it directly below.

Seems it was transposed with the var 'sum' in the subsequent example.